### PR TITLE
deps: freeze only major versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.5.1
-lxml==3.4.2
+requests~=2.27.1
+lxml~=4.8.0


### PR DESCRIPTION
We had old dependencies fixed in requirements.txt. I have problems with
installing them with Python 3.10. It is time to update.

I don't see a reason to freeze a fully specified version of the
dependencies. So I decided to freeze only major version using the
compatible release clause (`~=`).

Changed major lxml version, because I don't see any degradations since
lxml-3 for the tool.