### PR TITLE
readme: add known problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,28 @@ More options described in the cheatsheet, which can be displayed by `./what_if_p
 
 Resulting HTML and Markdown will saved into files like `001-relativistic-baseball-20160210-232959+0300.html` and `001-relativistic-baseball-20160210-232959+0300.html`. A timestamp added for simplify tracking changes.
 
+## Known problems
+
+The HTML layout was changed on the website and the tool does not reflect it.
+
+The article number/title is necessary to generate a 'slug', but they're not
+parsed at the moment. I use the following workaround for a while:
+
+```diff
+diff --git a/what_if_parse.py b/what_if_parse.py
+index e196e9b..b8789c6 100755
+--- a/what_if_parse.py
++++ b/what_if_parse.py
+@@ -446,6 +446,7 @@ def process_article(url, html):
+         'blockquote': process_toplevel_blockquote,
+         'img': process_toplevel_img,
+     }
++    state['slug'] = '158-hot-banana'
+     for child in article:
+         logging.info('Processed %d/%d top level elements',
+                      childs_processed, childs_cnt)
+```
+
 ## License
 
 The code, documentation and other repository content are in public domain.


### PR DESCRIPTION
The layout on the website was updated, but the tool is not updated
accordingly at the moment.

Grabbing of the title should be simple, but I don't see how I can deduce
an article number (if it is not set in the argument) aside of parsing
images URLs. Postponed for now, proposed a workaround.